### PR TITLE
Melhore a representação de valores ilimitados

### DIFF
--- a/UI/menu_pausa.gd
+++ b/UI/menu_pausa.gd
@@ -52,7 +52,7 @@ func _ready() -> void:
 	$"HSliderSons".set_value_no_signal(db_to_linear(AudioServer.get_bus_volume_db(AudioServer.get_bus_index("SFX"))) * 100)
 	$"AspectRatioContainerBotãoSons/BotãoSons".icon = ícone_sons_mudo_normal if GameManager.sons_mutados else ícone_sons_normal
 	
-	if GameManager.vidas != 2147483647:
+	if GameManager.vidas != GameManager.INT_MAX:
 		$LineEditVidas.text = str(GameManager.vidas)
 	else:
 		$LineEditVidas.text = "Ilimitadas"
@@ -177,21 +177,23 @@ func _on_line_edit_vidas_text_changed(new_text: String) -> void:
 		GameManager.vidas = valor
 		número_de_vidas_mudou.emit(valor)
 	else:
-		GameManager.vidas = 2147483647
-		número_de_vidas_mudou.emit(2147483647)
+		GameManager.vidas = GameManager.INT_MAX
+		número_de_vidas_mudou.emit(GameManager.INT_MAX)
 
 
 func _on_line_edit_vidas_text_submitted(new_text: String) -> void:
 	var valor: int = int(new_text)
+
+	if valor <= 0:
+		valor = GameManager.INT_MAX
 	
-	if valor > 0:
-		GameManager.vidas = valor
-		$LineEditVidas.text = str(valor)
-		número_de_vidas_mudou.emit(valor)
+	GameManager.vidas = valor
+	número_de_vidas_mudou.emit(valor)
+
+	if valor == GameManager.INT_MAX:
+		$"LineEditVidas".text = "Ilimitadas"
 	else:
-		GameManager.vidas = 2147483647
-		$LineEditVidas.text = "Ilimitadas"
-		número_de_vidas_mudou.emit(2147483647)
+		$"LineEditVidas".text = str(valor)
 
 
 func _on_botão_finalizar_sessão_pressed() -> void:

--- a/UI/tela_pré_teste.gd
+++ b/UI/tela_pré_teste.gd
@@ -190,23 +190,29 @@ func atualizar_repetição(new_text: String) -> void:
 func atualizar_vidas(new_text: String) -> void:
 	var vidas: int = int(new_text)
 	
-	if vidas <= 0 or new_text.to_lower() == "ilimitadas":
+	if vidas <= 0:
+		vidas = GameManager.INT_MAX
+	
+	GameManager.vidas = vidas
+	
+	if vidas == GameManager.INT_MAX:
 		$ScrollContainer/Control/LineEditVidas.text = "Ilimitadas"
-		GameManager.vidas = 2147483647
 	else:
 		$ScrollContainer/Control/LineEditVidas.text = str(vidas)
-		GameManager.vidas = vidas
 
 
 func atualizar_duração(new_text: String) -> void:
 	var duração: float = float(new_text)
 	
-	if duração <= 0.0 or new_text.to_lower() == "ilimitada":
+	if duração <= 0.0:
+		duração = INF
+	
+	GameManager.duração = duração
+	
+	if duração == INF:
 		$"ScrollContainer/Control/LineEditDuração".text = "Ilimitada"
-		GameManager.duração = INF
 	else:
 		$"ScrollContainer/Control/LineEditDuração".text = str(duração)
-		GameManager.duração = duração
 
 
 func id_profissional_inválido() -> void:

--- a/scenes/game_manager/game_manager.gd
+++ b/scenes/game_manager/game_manager.gd
@@ -1,6 +1,9 @@
 extends Node2D
 
 
+const INT_MIN: int = -9223372036854775808
+const INT_MAX: int = 9223372036854775807
+
 enum PolíticasDeReposicionamento {
 	NENHUM,
 	ALVO,
@@ -193,7 +196,7 @@ func iniciar_jogo() -> void:
 	get_tree().change_scene_to_file("res://scenes/jogo_principal/jogo_principal.tscn")
 
 
-func iniciar_jogo_com_parâmetros(número_alvos: int = número_máximo_de_alvos, tempo_de_duração: float = 120.0, política_de_reposicionamento_do_jogo: int = PolíticasDeReposicionamento.TODOS, repetição: int = 3, requisito_para_pontuar: int = Requisitos.TODOS, velocidade_dos_alvos: int = Velocidades.MÉDIA, id_prof: String = "", mostrar_tempo: bool = true, número_de_vidas: int = 2147483647, animar_ícones: bool = true) -> void:
+func iniciar_jogo_com_parâmetros(número_alvos: int = número_máximo_de_alvos, tempo_de_duração: float = 120.0, política_de_reposicionamento_do_jogo: int = PolíticasDeReposicionamento.TODOS, repetição: int = 3, requisito_para_pontuar: int = Requisitos.TODOS, velocidade_dos_alvos: int = Velocidades.MÉDIA, id_prof: String = "", mostrar_tempo: bool = true, número_de_vidas: int = INT_MAX, animar_ícones: bool = true) -> void:
 	número_de_alvos = min(número_alvos, número_máximo_de_alvos)
 	duração = tempo_de_duração
 	política_de_reposicionamento = política_de_reposicionamento_do_jogo
@@ -234,7 +237,7 @@ func toque(alvos: Array[int]) -> bool:
 		
 		pontos_real -= 1
 		
-		if vidas != 2147483647:
+		if vidas != INT_MAX:
 			vidas -= 1
 		
 		log_data.append([id_sessão, id_profissional, data_sessão, timestamp_atual_sessão, nome_jogo, tempo_resposta, pontos_real, alvo_atual, false, suporte, Velocidades.find_key(velocidade), vidas])  # Exemplo de log com erro

--- a/scenes/jogo_principal/jogo_principal.gd
+++ b/scenes/jogo_principal/jogo_principal.gd
@@ -77,7 +77,7 @@ func _ready() -> void:
 		grid_de_alvos[i] = array_temporário.duplicate()
 	
 	# A primeira célula é reservada para o indicador do alvo atual
-	grid_de_alvos[0][0] = 2147483647
+	grid_de_alvos[0][0] = GameManager.INT_MAX
 	
 	var aspect_ratio_célula: float = tamanho_célula.y / tamanho_célula.x
 	offset_máximo = Vector2(BASE_OFFSET_MÁXIMO * GameManager.escala, BASE_OFFSET_MÁXIMO * GameManager.escala * aspect_ratio_célula)
@@ -151,7 +151,7 @@ func _ready() -> void:
 	$CanvasLayer/LabelPontos.add_theme_font_size_override("font_size", GameManager.escala * TAMANHO_BASE_DA_FONTE)
 	$CanvasLayer/LabelVidas.add_theme_font_size_override("font_size", GameManager.escala * TAMANHO_BASE_DA_FONTE)
 
-	if GameManager.vidas == 2147483647:
+	if GameManager.vidas == GameManager.INT_MAX:
 		$CanvasLayer/LabelVidas.visible = false
 		$CanvasLayer/Heart.visible = false
 		$CanvasLayer/HeartAnimation.visible = false
@@ -242,10 +242,10 @@ func _process(delta: float) -> void:
 			if GameManager.vidas != 0:
 				$TapWrong.play()
 				
-				if GameManager.animar and GameManager.vidas != 2147483647:
+				if GameManager.animar and GameManager.vidas != GameManager.INT_MAX:
 					$CanvasLayer/HeartAnimation.play()
 				
-				if GameManager.vidas != 2147483647:
+				if GameManager.vidas != GameManager.INT_MAX:
 					$CanvasLayer/MenuPausa/LineEditVidas.text = str(GameManager.vidas)
 			
 		atualizar_placar()
@@ -320,7 +320,7 @@ func atualizar_placar() -> void:
 	
 
 func atualizar_vidas() -> void:
-	if GameManager.vidas != 2147483647:
+	if GameManager.vidas != GameManager.INT_MAX:
 		$CanvasLayer/LabelVidas.text = str(GameManager.vidas)
  
 
@@ -409,7 +409,7 @@ func remover_todos_os_alvos_do_grid() -> void:
 		for j: int in grid_de_alvos[i].size():
 			grid_de_alvos[i][j] = -1
 
-	grid_de_alvos[0][0] = 2147483647
+	grid_de_alvos[0][0] = GameManager.INT_MAX
 
 
 func centro_de_alvo(alvo: int) -> Vector2:
@@ -462,7 +462,7 @@ func _on_menu_pausa_barra_de_tempo_oculta(oculta: bool) -> void:
 
 
 func _on_menu_pausa_número_de_vidas_mudou(vidas: int) -> void:
-	if vidas == 2147483647:
+	if vidas == GameManager.INT_MAX:
 		$CanvasLayer/LabelVidas.visible = false
 		$CanvasLayer/Heart.visible = false
 		$CanvasLayer/HeartAnimation.visible = false


### PR DESCRIPTION
Anteriormente valores ilimitados eram representados com `2147483647`, que é o valor máximo de um inteiro com sinal de 32 bits. Porém, a Godot utiliza inteiros de 64 bits, que possuem valor máximo `9223372036854775807`.

Foi definida uma constante `INT_MAX` no `GameManager` para representar o valor máximo de um inteiro, e agora os valores ilimitados no código utilizam essa constante.

Um efeito disso foi que agora ao entrar um valor maior ou igual a 9223372036854775807 em campos que tomam inteiros, o valor será interpretado como ilimitado, então o texto passará agora a exibir um texto representando que o valor é ilimitado nesse caso.