### PR TITLE
Altere o modo de esticar a janela

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,11 @@ config/icon="res://icon.svg"
 
 GameManager="*res://scenes/game_manager/game_manager.tscn"
 
+[display]
+
+window/stretch/mode="canvas_items"
+window/stretch/aspect="expand"
+
 [input]
 
 pausar={


### PR DESCRIPTION
O modo de esticar a janela estava setado como `disabled`, fazendo com que elementos 2D não se ajustassem corretamente ao tamanho da tela. O modo foi alterado para `canvas_items`, e a proporção da tela foi setada para `expand`, fazendo com que a interface se adapte a telas com diferentes proporções.

Isso tem como efeito prático fazer com que os cantos arredondados dos elementos de interface tenham o tamanho certo, anteriormente eles tinham um tamanho fixo em pixels, fazendo com que ficassem muito pequenos em telas com dimensões maiores que a do viewport e muito grandes em telas com dimensões menores.